### PR TITLE
Improve Exception Handling

### DIFF
--- a/couchbase.go
+++ b/couchbase.go
@@ -42,7 +42,6 @@ func (c *Client) Insert(bucketName, scope, collection, docId string, doc any) er
 	col := bucket.Scope(scope).Collection(collection)
 	_, err = col.Insert(docId, doc, nil)
 	if err != nil {
-		// fmt.Errorf("Error during Insert Operation: %v", err)
 		return err
 	}
 	return nil

--- a/couchbase.go
+++ b/couchbase.go
@@ -27,7 +27,6 @@ func (*CouchBase) NewClient(connectionString, username, password string) interfa
 		},
 	})
 	if err != nil {
-		fmt.Errorf("Error during Client Connection: %v", err)
 		return err
 	}
 
@@ -38,13 +37,12 @@ func (c *Client) Insert(bucketName, scope, collection, docId string, doc any) er
 	bucket := c.client.Bucket(bucketName)
 	err := bucket.WaitUntilReady(5*time.Second, nil)
 	if err != nil {
-		fmt.Errorf("Error during Insert Operation: %v", err)
 		return err
 	}
 	col := bucket.Scope(scope).Collection(collection)
 	_, err = col.Insert(docId, doc, nil)
 	if err != nil {
-		fmt.Errorf("Error during Insert Operation: %v", err)
+		// fmt.Errorf("Error during Insert Operation: %v", err)
 		return err
 	}
 	return nil
@@ -54,13 +52,11 @@ func (c *Client) Upsert(bucketName, scope, collection, docId string, doc any) er
 	bucket := c.client.Bucket(bucketName)
 	err := bucket.WaitUntilReady(5*time.Second, nil)
 	if err != nil {
-		fmt.Errorf("Error during Upsert Operation: %v", err)
 		return err
 	}
 	col := bucket.Scope(scope).Collection(collection)
 	_, err = col.Upsert(docId, doc, nil)
 	if err != nil {
-		fmt.Errorf("Error during Upsert Operation: %v", err)
 		return err
 	}
 	return nil
@@ -70,7 +66,6 @@ func (c *Client) Remove(bucketName, scope, collection, docId string) error {
 	bucket := c.client.Bucket(bucketName)
 	err := bucket.WaitUntilReady(5*time.Second, nil)
 	if err != nil {
-		fmt.Errorf("Error during Remove Operation: %v", err)
 		return err
 	}
 
@@ -82,7 +77,6 @@ func (c *Client) Remove(bucketName, scope, collection, docId string) error {
 		DurabilityLevel: gocb.DurabilityLevelMajority,
 	})
 	if err != nil {
-		fmt.Errorf("Error during Remove Operation: %v", err)
 		return err
 	}
 	return nil
@@ -99,13 +93,11 @@ func (c *Client) InsertBatch(bucketName, scope, collection string, docs map[stri
 	bucket := c.client.Bucket(bucketName)
 	err := bucket.WaitUntilReady(5*time.Second, nil)
 	if err != nil {
-		fmt.Errorf("Error during InsertBatch Operation: %v", err)
 		return err
 	}
 	col := bucket.Scope(scope).Collection(collection)
 	err = col.Do(batchItems, &gocb.BulkOpOptions{Timeout: 3 * time.Second})
 	if err != nil {
-		fmt.Errorf("Error during InsertBatch Operation: %v", err)
 		return err
 	}
 
@@ -120,7 +112,6 @@ func (c *Client) Find(query string) (any, error) {
 		&gocb.QueryOptions{},
 	)
 	if err != nil {
-		fmt.Errorf("Error during Find Operation: %v", err)
 		return result, err
 	}
 	// Print each found Row
@@ -128,7 +119,6 @@ func (c *Client) Find(query string) (any, error) {
 
 		err := queryResult.Row(&result)
 		if err != nil {
-			fmt.Errorf("Error during Find Operation: %v", err)
 			return result, err
 		}
 	}
@@ -141,20 +131,17 @@ func (c *Client) FindOne(bucketName, scope, collection, docId string) (any, erro
 	bucket := c.client.Bucket(bucketName)
 	err := bucket.WaitUntilReady(5*time.Second, nil)
 	if err != nil {
-		fmt.Errorf("Error during FindOne Operation: %v", err)
 		return result, err
 	}
 	bucketScope := bucket.Scope(scope)
 
 	getResult, err := bucketScope.Collection(collection).Get(docId, nil)
 	if err != nil {
-		fmt.Errorf("Error during FindOne Operation: %v", err)
 		return result, err
 	}
 
 	err = getResult.Content(&result)
 	if err != nil {
-		fmt.Errorf("Error during FindOne Operation: %v", err)
 		return result, err
 	}
 
@@ -171,7 +158,6 @@ func (c *Client) FindByPreparedStmt(query string, params ...interface{}) (any, e
 		},
 	)
 	if err != nil {
-		fmt.Errorf("Error during FindByPreparedStmt Operation: %v", err)
 		return result, err
 	}
 	// Print each found Row
@@ -179,7 +165,6 @@ func (c *Client) FindByPreparedStmt(query string, params ...interface{}) (any, e
 
 		err := queryResult.Row(&result)
 		if err != nil {
-			fmt.Errorf("Error during FindByPreparedStmt Operation: %v", err)
 			return result, err
 		}
 	}

--- a/couchbase.go
+++ b/couchbase.go
@@ -2,7 +2,6 @@ package xk6_couchbase
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/couchbase/gocb/v2"
@@ -28,7 +27,7 @@ func (*CouchBase) NewClient(connectionString, username, password string) interfa
 		},
 	})
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during Client Connection: %v", err)
 		return err
 	}
 
@@ -39,13 +38,13 @@ func (c *Client) Insert(bucketName, scope, collection, docId string, doc any) er
 	bucket := c.client.Bucket(bucketName)
 	err := bucket.WaitUntilReady(5*time.Second, nil)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during Insert Operation: %v", err)
 		return err
 	}
 	col := bucket.Scope(scope).Collection(collection)
 	_, err = col.Insert(docId, doc, nil)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during Insert Operation: %v", err)
 		return err
 	}
 	return nil
@@ -55,13 +54,13 @@ func (c *Client) Upsert(bucketName, scope, collection, docId string, doc any) er
 	bucket := c.client.Bucket(bucketName)
 	err := bucket.WaitUntilReady(5*time.Second, nil)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during Upsert Operation: %v", err)
 		return err
 	}
 	col := bucket.Scope(scope).Collection(collection)
 	_, err = col.Upsert(docId, doc, nil)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during Upsert Operation: %v", err)
 		return err
 	}
 	return nil
@@ -71,7 +70,7 @@ func (c *Client) Remove(bucketName, scope, collection, docId string) error {
 	bucket := c.client.Bucket(bucketName)
 	err := bucket.WaitUntilReady(5*time.Second, nil)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during Remove Operation: %v", err)
 		return err
 	}
 
@@ -83,10 +82,7 @@ func (c *Client) Remove(bucketName, scope, collection, docId string) error {
 		DurabilityLevel: gocb.DurabilityLevelMajority,
 	})
 	if err != nil {
-		panic(err)
-	}
-	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during Remove Operation: %v", err)
 		return err
 	}
 	return nil
@@ -103,13 +99,13 @@ func (c *Client) InsertBatch(bucketName, scope, collection string, docs map[stri
 	bucket := c.client.Bucket(bucketName)
 	err := bucket.WaitUntilReady(5*time.Second, nil)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during InsertBatch Operation: %v", err)
 		return err
 	}
 	col := bucket.Scope(scope).Collection(collection)
 	err = col.Do(batchItems, &gocb.BulkOpOptions{Timeout: 3 * time.Second})
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during InsertBatch Operation: %v", err)
 		return err
 	}
 
@@ -124,7 +120,7 @@ func (c *Client) Find(query string) (any, error) {
 		&gocb.QueryOptions{},
 	)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during Find Operation: %v", err)
 		return result, err
 	}
 	// Print each found Row
@@ -132,7 +128,7 @@ func (c *Client) Find(query string) (any, error) {
 
 		err := queryResult.Row(&result)
 		if err != nil {
-			log.Fatal(err)
+			fmt.Errorf("Error during Find Operation: %v", err)
 			return result, err
 		}
 	}
@@ -145,20 +141,20 @@ func (c *Client) FindOne(bucketName, scope, collection, docId string) (any, erro
 	bucket := c.client.Bucket(bucketName)
 	err := bucket.WaitUntilReady(5*time.Second, nil)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during FindOne Operation: %v", err)
 		return result, err
 	}
 	bucketScope := bucket.Scope(scope)
 
 	getResult, err := bucketScope.Collection(collection).Get(docId, nil)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during FindOne Operation: %v", err)
 		return result, err
 	}
 
 	err = getResult.Content(&result)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during FindOne Operation: %v", err)
 		return result, err
 	}
 
@@ -175,7 +171,7 @@ func (c *Client) FindByPreparedStmt(query string, params ...interface{}) (any, e
 		},
 	)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Errorf("Error during FindByPreparedStmt Operation: %v", err)
 		return result, err
 	}
 	// Print each found Row
@@ -183,7 +179,7 @@ func (c *Client) FindByPreparedStmt(query string, params ...interface{}) (any, e
 
 		err := queryResult.Row(&result)
 		if err != nil {
-			log.Fatal(err)
+			fmt.Errorf("Error during FindByPreparedStmt Operation: %v", err)
 			return result, err
 		}
 	}


### PR DESCRIPTION
## Summary
Currently, the plugin when encountering an error from the driver, logs messages using log.Fatal(err) that prints the error message and calls os.Exit(1) which terminates the program immediately without letting users try/catch the exception in k6.js files.

This PR removes the use of log.Fatal() which but allows users to try/catch the exceptions in the k6 JS files and if not print the message.

## Testing
k6 script (truncated to remove user/pass etc.):
```
// This code is run once before any VUs are started.
export function setup() {
    const key_prefix = 'k6:prefix:';

    console.log(`Connected to ${hostname}`);
    console.log(`inserting ${doc_count} documents into ${bucket_name}.${scope_name}.${collection_name} with key prefix ${key_prefix} ...`);

    const i = 0;
    try {
        client.insert(bucket_name, scope_name, collection_name, key_prefix + i, { 'hello': 'world' });
        client.insert(bucket_name, scope_name, collection_name, key_prefix + i, { 'hello': 'world' });

    } catch (error) {
        console.log('error inserting document: ' + error);
    }

    console.log('done inserting')
    return { key_prefix: key_prefix };
}

export default function (data) {
    const key = data.key_prefix + Math.floor(Math.random() * doc_count)

    var res = client.findOne(bucket_name, scope_name, collection_name, key);
    console.log(res)
}
```

Current: Program immediately exits and does not honor the try/catch
```
$ ./code/xk6-couchbase/xk6-couchbase run --duration 2s ~/code/k6-scripts/exception_cb.js

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

     execution: local
        script: /home/amchaudh/code/k6-scripts/exception_cb.js
        output: -

     scenarios: (100.00%) 1 scenario, 1 max VUs, 32s max duration (incl. graceful stop):
              * default: 1 looping VUs for 2s (gracefulStop: 30s)

INFO[0000] Connected to test-hdd-1.in-couchbase.ei4.ird.disco.linkedin.com  source=console
INFO[0000] inserting 1 documents into beer-sample._default.k6 with key prefix k6:prefix: ...  source=console
INFO[0000] 2024/09/06 17:20:42 document exists | {"status_code":2,"document_id":"k6:prefix:0","bucket":"beer-sample","scope":"_default","collection":"k6","collection_id":8,"error_name":"KEY_EEXISTS","error_description":"key already exists, or CAS mismatch","opaque":8,"last_dispatched_to":"lor1-0000866.int.linkedin.com:11210","last_dispatched_from":"100.76.134.11:52988","last_connection_id":"067822df61e7c430/40e82ea512b8b0f8"}
$
$ ====================] setup()
$ --------------------]
```

New Behavior: try/catch works as expected
```

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

     execution: local
        script: /home/amchaudh/code/k6-scripts/exception_cb.js
        output: -

     scenarios: (100.00%) 1 scenario, 1 max VUs, 32s max duration (incl. graceful stop):
              * default: 1 looping VUs for 2s (gracefulStop: 30s)

INFO[0000] Connected to test-hdd-1.in-couchbase.ei4.ird.disco.linkedin.com  source=console
INFO[0000] inserting 1 documents into beer-sample._default.k6 with key prefix k6:prefix: ...  source=console
INFO[0000] error inserting document: GoError: document exists | {"status_code":2,"document_id":"k6:prefix:0","bucket":"beer-sample","scope":"_default","collection":"k6","collection_id":8,"error_name":"KEY_EEXISTS","error_description":"key already exists, or CAS mismatch","opaque":8,"last_dispatched_to":"lor1-0000866.int.linkedin.com:11210","last_dispatched_from":"100.76.134.11:47206","last_connection_id":"48b5ab73fc7067ed/a60e54da7b4af4f4"}  source=console
INFO[0000] done inserting                                source=console
INFO[0001] {"hello":"world"}                             source=console
INFO[0001] {"hello":"world"}                             source=console
INFO[0001] {"hello":"world"}                             source=console
INFO[0001] {"hello":"world"}                             source=console
INFO[0001] {"hello":"world"}                             source=console
INFO[0001] {"hello":"world"}                             source=console
INFO[0001] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0002] {"hello":"world"}                             source=console
INFO[0003] {"hello":"world"}                             source=console

     data_received........: 0 B 0 B/s
     data_sent............: 0 B 0 B/s
     iteration_duration...: avg=78.68ms min=38.31ms med=38.44ms max=740.87ms p(90)=38.63ms p(95)=251.78ms
     iterations...........: 34  12.336728/s
     vus..................: 1   min=1       max=1
     vus_max..............: 1   min=1       max=1


running (02.8s), 0/1 VUs, 34 complete and 0 interrupted iterations
default ✓ [======================================] 1 VUs  2s
```